### PR TITLE
fix: remove the setting of TestDatabase as a default option

### DIFF
--- a/src/ExperianModels/Options.php
+++ b/src/ExperianModels/Options.php
@@ -24,6 +24,5 @@ class Options extends Base
         "FullFBLRequired"          => true,
         "AuthenticatePlusRequired" => true,
         "DetectRequired"           => true,
-        "TestDatabase"             => Database::AGED,
     ];
 }


### PR DESCRIPTION
Having the `TestDatabase` property in the `Options` element of a submission causes an error in the Experian production environment.

This element should be added to `Options` by the caller when they know they are accessing Experian's UAT environment.

e.g.
```
        if (config('experian.mode') === 'uat') {
            $submission->Options->TestDatabase = Database::AGED;
        }
```